### PR TITLE
Update README to pass array as :on option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Options are as follows:
 * :on - generates token on certain time: :initialize, :create (default), :update.
 
     ```ruby
-    has_token_on :slug, :on => :initialize
+    has_token_on :slug, :on => [:initialize]
     ```
 
 * :seed - elements or functions that are used to generate hash. Options:


### PR DESCRIPTION
``` ruby
has_token_on :slug, :on => :initialize
```

Doesn't work, `:on` options must be an array. I updated README to not confuse users.
